### PR TITLE
Maintain partially-filled template strings

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -8,7 +8,11 @@ const templater = (template, context) => {
     if (typeof template === 'string') {
         const match = template.match(/{{2}([\w.]+)(?=}{2})/);
         if (match) {
-            return Hoek.reach(context, match[1]);
+            const reachedValue = Hoek.reach(context, match[1]);
+
+            if (reachedValue !== undefined) {
+                return reachedValue;
+            }
         }
 
         return template;

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -46,6 +46,17 @@ describe('Templater', () => {
         });
     });
 
+    it('should leave unfilled templates in place', () => {
+
+        return Templater({ foo: '{{bob}}', bar: '{{baz}}' }, null, { context: {
+            bob: 'bar'
+        } })
+        .then( (result) => {
+
+            expect(result).to.equal({ foo: 'bar', bar: '{{baz}}' });
+        });
+    });
+
     it('should default to the local context', () => {
 
         const localContext = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If a property is not found in the provided context, the template string is left in place.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
### Old Behavior
```js
return Templater({ foo: '{{bob}}', bar: '{{baz}}' }, null, { context: {
            bob: 'bar'
        } })
        .then( (result) => {

           // result === { foo: 'bar', bar: undefined }
        });
```
### New Behavior
```js
return Templater({ foo: '{{bob}}', bar: '{{baz}}' }, null, { context: {
            bob: 'bar'
        } })
        .then( (result) => {

           // result === { foo: 'bar', bar: '{{baz}}' }
        });
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.