### PR TITLE
Renames data context; separates joi options

### DIFF
--- a/API.md
+++ b/API.md
@@ -25,6 +25,10 @@ An optional joi schema. Validation will be done against the hydrated object. Thi
 
 #### options
 
-##### context
+##### hydrationContext
 
 Used to override the default context from `this.contexts`
+
+##### joiOptions
+
+Passes options (such as `allowUnknown`) to the `Joi.validate` call if a schema is provided.

--- a/Example.md
+++ b/Example.md
@@ -56,7 +56,7 @@ Templater(
     },
     null,
     {
-        context: {
+        hydrationContext: {
             name: 'Bob'
         }
     }

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -3,12 +3,12 @@
 const Hoek = require('hoek');
 const Joi = require('joi');
 
-const templater = (template, context) => {
+const templater = (template, hydrationContext) => {
 
     if (typeof template === 'string') {
         const match = template.match(/{{2}([\w.]+)(?=}{2})/);
         if (match) {
-            const reachedValue = Hoek.reach(context, match[1]);
+            const reachedValue = Hoek.reach(hydrationContext, match[1]);
 
             if (reachedValue !== undefined) {
                 return reachedValue;
@@ -20,7 +20,7 @@ const templater = (template, context) => {
 
     Object.keys(template).forEach((key) => {
 
-        template[key] = templater(template[key], context);
+        template[key] = templater(template[key], hydrationContext);
     });
 
     return template;
@@ -34,21 +34,21 @@ module.exports = function (source, schema, options = {}) {
             source = this.config || {};
         }
 
-        let context = null;
-        if (options.context) {
-            context = options.context;
+        let hydrationContext = null;
+        if (options.hydrationContext) {
+            hydrationContext = options.hydrationContext;
         }
         else if (this && this.contexts) {
-            context = this.contexts;
+            hydrationContext = this.contexts;
         }
         else {
-            context = {};
+            hydrationContext = {};
         }
 
-        const output = templater(source, context);
+        const output = templater(source, hydrationContext);
 
         if (schema) {
-            const validated = Joi.validate(output, schema, options);
+            const validated = Joi.validate(output, schema, options.joiOptions);
 
             if (validated.error) {
                 return reject(validated.error);

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -37,7 +37,7 @@ describe('Templater', () => {
 
     it('should fill out an object template', () => {
 
-        return Templater({ foo: '{{bob}}' }, null, { context: {
+        return Templater({ foo: '{{bob}}' }, null, { hydrationContext: {
             bob: 'bar'
         } })
         .then( (result) => {
@@ -48,7 +48,7 @@ describe('Templater', () => {
 
     it('should leave unfilled templates in place', () => {
 
-        return Templater({ foo: '{{bob}}', bar: '{{baz}}' }, null, { context: {
+        return Templater({ foo: '{{bob}}', bar: '{{baz}}' }, null, { hydrationContext: {
             bob: 'bar'
         } })
         .then( (result) => {
@@ -90,7 +90,7 @@ describe('Templater', () => {
 
     it('should fill out a multi-level object template', () => {
 
-        return Templater({ foo: '{{foo.bob}}' }, null, { context: {
+        return Templater({ foo: '{{foo.bob}}' }, null, { hydrationContext: {
             foo: {
                 bob: 'bar'
             }
@@ -103,7 +103,7 @@ describe('Templater', () => {
 
     it('should fill out an array template', () => {
 
-        return Templater(['{{foo}}', '{{bar}}', '{{bob}}'], null, { context: {
+        return Templater(['{{foo}}', '{{bar}}', '{{bob}}'], null, { hydrationContext: {
             foo: 'foo stuff',
             bar: {
                 bar: 'stuff'
@@ -124,7 +124,7 @@ describe('Templater', () => {
 
     it('should hydrate an array value', () => {
 
-        return Templater({ foo: '{{foo}}' }, null, { context: {
+        return Templater({ foo: '{{foo}}' }, null, { hydrationContext: {
             foo: [
                 {
                     bob: 'bar'
@@ -140,7 +140,7 @@ describe('Templater', () => {
     it('should fill an object blob', () => {
 
         return Templater({ foo: '{{foo}}' }, null, {
-            context: {
+            hydrationContext: {
                 foo: {
                     bob: 'bar'
                 }
@@ -155,7 +155,7 @@ describe('Templater', () => {
     it('should fill a mutli-level object blob', () => {
 
         return Templater({ foo: '{{foo}}' }, null, {
-            context: {
+            hydrationContext: {
                 foo: {
                     bob: 'bar',
                     baz: {
@@ -174,7 +174,7 @@ describe('Templater', () => {
 
         return Templater({ foo: '{{foo.bob}}' }, {
             foo: Joi.string()
-        }, { context: {
+        }, { hydrationContext: {
             foo: {
                 bob: 'bar'
             }
@@ -190,12 +190,14 @@ describe('Templater', () => {
         return Templater({ foo: '{{foo.bob}}', baz: 'please do not fail me' }, {
             foo: Joi.string()
         }, {
-            context: {
+            hydrationContext: {
                 foo: {
                     bob: 'bar'
                 }
             },
-            allowUnknown: true
+            joiOptions      : {
+                allowUnknown : true
+            }
         })
         .then( (result) => {
 
@@ -207,7 +209,7 @@ describe('Templater', () => {
 
         return Templater({ foo: '{{foo.bob}}' }, {
             bob: Joi.string()
-        }, { context: {
+        }, { hydrationContext: {
             foo: {
                 bob: 'bar'
             }
@@ -218,4 +220,19 @@ describe('Templater', () => {
         });
     });
 
+    it('should not throw uncaught errors when hydrationContext is not an object', () => {
+
+        return Templater({ foo: '{{foo.bob}}' }, {
+            foo: Joi.string()
+        }, {
+            hydrationContext: 200,
+            joiOptions      : {
+                allowUnknown : true
+            }
+        })
+        .then( (result) => {
+
+            expect(result).to.equal({ foo: '{{foo.bob}}' });
+        });
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This breaks out the data hydration context and the Joi-specific options.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
none

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In toki-method-http, when a template schema is passed to toki-templater along with the server response the `context` property was passed to Joi validation, which incidentally supports a `context` option. If the server response was not an object (string or statusCode integer), the Joi validation would throw an uncaught exception because of the conflation of the `context` properties in the options.

This PR splits out the Joi-specific options to be passed to `Joi.validate` explicitly. It also renames the `context` property to `hydrationContext` for clarity.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.