### PR TITLE
Supports interpolated template strings

### DIFF
--- a/API.md
+++ b/API.md
@@ -19,6 +19,9 @@ Require in the module and call it with the template you want hydrated, an option
 
 The template to be hydrated. Can be passed in as a JSON string or an option. If not provided, `this.config` will be used.
 
+If the `{{}}` template handlebar is interpolated in a string (`/route/{{example.id}}`) then the returned value will be a string.
+If the template handlebar is the entire template value (`{{example}}`) then the returned value will be whatever the target value is.
+
 #### schema
 
 An optional joi schema. Validation will be done against the hydrated object. This is only used if you pass in an object.

--- a/Example.md
+++ b/Example.md
@@ -66,3 +66,24 @@ Templater(
     console.log('Oops! Name not long enough!');
 });
 ```
+
+### Interpolated string
+
+```Javascript
+const Templater = require('toki-templater');
+
+Templater(
+    '/route/{{document.id}}/example',
+    null,
+    {
+        hydrationContext: {
+            document: {
+                id: 'GUID'
+            }
+        }
+    }
+).then( (hydratedConfig) => {
+    console.log(hydratedConfig);
+    // '/route/GUID/example'
+});
+```

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -6,13 +6,46 @@ const Joi = require('joi');
 const templater = (template, hydrationContext) => {
 
     if (typeof template === 'string') {
-        const match = template.match(/{{2}([\w.]+)(?=}{2})/);
-        if (match) {
-            const reachedValue = Hoek.reach(hydrationContext, match[1]);
+        const fullTemplatePattern = /^{{2}([\w.]+)(?=}{2}$)/;
+        const interpolatedTemplatePattern = /{{2}([\w.]+)(}{2})/g;
+        const fullTemplateMatch = template.match(fullTemplatePattern);
+
+        if (fullTemplateMatch) {
+            const reachedValue = Hoek.reach(hydrationContext, fullTemplateMatch[1]);
 
             if (reachedValue !== undefined) {
                 return reachedValue;
             }
+        }
+        else {
+            let result = '';
+
+            template.split(interpolatedTemplatePattern).forEach((templateChunk, index, templatePieces) => {
+
+                if (templateChunk === '}}') {
+                    return;
+                }
+                else if (templatePieces[index + 1] === '}}') {
+                    const reachedValue = Hoek.reach(hydrationContext, templateChunk);
+
+                    if (reachedValue !== undefined) {
+                        if (typeof reachedValue === 'object') {
+                            result += JSON.stringify(reachedValue);
+                        }
+                        else {
+                            result += reachedValue;
+                        }
+                    }
+                    else {
+                        result += '{{' + templateChunk + '}}';
+                    }
+                }
+                else {
+                    result += templateChunk;
+                }
+            });
+
+            return result;
         }
 
         return template;

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -35,6 +35,33 @@ describe('Templater', () => {
         });
     });
 
+    it('should return an interpolated string', () => {
+
+        return Templater('foo {{bar}}', null, { hydrationContext: { bar: 'baz' } })
+        .then( (result) => {
+
+            expect(result).to.equal('foo baz');
+        });
+    });
+
+    it('should return an interpolated string with a stringified object', () => {
+
+        return Templater('foo {{bar}}', null, { hydrationContext: { bar: { nested: 'baz' } } })
+        .then( (result) => {
+
+            expect(result).to.equal('foo {"nested":"baz"}');
+        });
+    });
+
+    it('should return an interpolated string with multiple templated values', () => {
+
+        return Templater('/example/{{foo}}/{{bar}}/{{not.yet}}', null, { hydrationContext: { foo: 'dynamic', bar: 'route' } })
+        .then( (result) => {
+
+            expect(result).to.equal('/example/dynamic/route/{{not.yet}}');
+        });
+    });
+
     it('should fill out an object template', () => {
 
         return Templater({ foo: '{{bob}}' }, null, { hydrationContext: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds support for interpolated template strings like `'route/{{dynamic.property}}'`.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #7 

## Motivation and Context
Adds functionality important to expanding use cases of toki-method plugins.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.